### PR TITLE
Fix broken logo links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Awesome Jupyter Book [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+# Awesome Jupyter Book [![Awesome](https://awesome.re/badge.svg)](https://github.com/sindresorhus/awesome)
 
 ![All Contributors](https://img.shields.io/github/all-contributors/tkoyama010/awesome-jupyter-book?color=ee8449)
 
 <p align="center">
-    <img src="https://jupyterbook.org/en/stable/_static/logo-wide.svg" alt="1280px-Mandel_zoom_00_mandelbrot_set" width="400"/>
+    <img src="https://raw.githubusercontent.com/executablebooks/jupyter-book/master/docs/images/logo-wide.svg" alt="Jupyter Book Logo" width="400"/>
 </p>
 
 > Jupyter Book is an open-source tool for building publication-quality books and documents from computational material.


### PR DESCRIPTION
## Summary
This PR fixes broken logo links in the README that were returning 404 errors or using outdated URLs.

## Changes
- Updated Jupyter Book logo URL from `https://jupyterbook.org/en/stable/_static/logo-wide.svg` (404 error) to the official GitHub raw content URL
- Updated Awesome badge URL from the old CDN URL to the current recommended `https://awesome.re/badge.svg`
- Improved alt text for Jupyter Book logo for better accessibility

## Test plan
- [x] Verified both new URLs are accessible and return valid images
- [x] Checked that images display correctly in GitHub's markdown preview

🤖 Generated with [Claude Code](https://claude.ai/code)